### PR TITLE
PUPPI muon isolation has been added.

### DIFF
--- a/AnalysisCode/interface/YggdrasilEventVars.h
+++ b/AnalysisCode/interface/YggdrasilEventVars.h
@@ -101,6 +101,7 @@ struct yggdrasilEventVars{
   vdouble lepton_phi_;
   vdouble lepton_e_;
   vdouble lepton_relIso_;
+  vdouble lepton_puppirelIso_;
   vdouble lepton_scEta_;
 
   Float_t wgt_lumi_;
@@ -240,6 +241,7 @@ void yggdrasilEventVars::initialize(){
   lepton_phi_.clear();
   lepton_e_.clear();
   lepton_relIso_.clear();
+  lepton_puppirelIso_.clear();
   lepton_scEta_.clear();
 
   wgt_generator_        = -99.9;

--- a/README.txt
+++ b/README.txt
@@ -12,8 +12,8 @@ setenv SCRAM_ARCH slc6_amd64_gcc530
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 export SCRAM_ARCH=slc6_amd64_gcc530
 
-cmsrel CMSSW_8_0_11
-cd CMSSW_8_0_11/src/
+cmsrel CMSSW_8_0_12
+cd CMSSW_8_0_12/src/
 cmsenv
 
 #[skip this for the moment]  # Apply bug fix of met correction. 

--- a/README.txt
+++ b/README.txt
@@ -26,9 +26,9 @@ cmsenv
 git clone https://github.com/hsatoshi/MiniAOD.git -b satoshi__CMSSW_8_0_8
 git clone https://github.com/hsatoshi/ttH-LeptonPlusJets.git -b satoshi_cleanup_80x_Sync2nd
 git clone https://github.com/hsatoshi/GenParticleTopOriginChargedleptonFilter.git ttHAnalysisSubprogram/GenParticleTopOriginChargedleptonFilter
+git clone https://github.com/hsatoshi/PuppiLeptonIsolationhelper.git
 
 scram b -j 10 ; scram b -j 10
-# Due to [*1], compile takes time. Brew a cup of coffee. while waiting.
 # Yes,.. compile twice for the moment. First compile claims errors while the second works. Need to be solved.
 
 
@@ -105,6 +105,8 @@ lepton_e_       : energy
 lepton_isMuon_  : If muon, 1. If electron, 0. 
 lepton_relIso_  : Muon, delta_beta corrected relative isolation. cone 04. Calculated with MiniAODHelper.
                 : Ele , EffectiveArea-corrected isolation, cone 0.3 (Calculated with MiniAODHelper with effAreaType::spring15)
+lepton_puppirelIso_  : Muon , PUPPI isolation
+                     : Ele  , (same as lepton_relIso_ for the moment.)
 lepton_isTight_ : POG Tight ID. 1=pass. [*1] 
 lepton_isLoose_ : POG Loose ID. 1=pass. [*1]
 lepton_scEta_   : Electron Super Cluster. For muon, -99 is filled.

--- a/YggdrasilTreeMaker/test/yggdrasil_treeMaker_cfg.py
+++ b/YggdrasilTreeMaker/test/yggdrasil_treeMaker_cfg.py
@@ -363,10 +363,17 @@ process.TFileService = cms.Service("TFileService",
 	fileName = cms.string('yggdrasil_treeMaker.root')
 )
 
+process.PUPPIMuonRelIso = cms.EDProducer('PuppiLeptonIsolation'
+                                         , srcLepton =cms.string('slimmedMuons')
+                                         , dR = cms.double( 0.4 ) 
+                                         , mixFraction = cms.double( 0.5 ) 
+                                         , configuration = cms.string( "##" )
+                                         )
+
 if isMC : 
     process.p = cms.Path(
         process.GenParticleWithoutChargedLeptonFropTop * process.myGenParticlesWithChargedLeptonFromTopForJet * process.ak4GenJetsWithChargedLepFromTop *  
-        process.electronMVAValueMapProducer * process.ttHTreeMaker)
+        process.PUPPIMuonRelIso * process.electronMVAValueMapProducer * process.ttHTreeMaker)
 else :
     process.p = cms.Path(
-        process.electronMVAValueMapProducer * process.ttHTreeMaker)
+        process.PUPPIMuonRelIso * process.electronMVAValueMapProducer * process.ttHTreeMaker)


### PR DESCRIPTION
PUPPI muon isolation has been added.
 - traditional isolation remains as the standard
 - PUPPIisolation for electron is coming. For the moment, the variables stores the standard one (= the same as lepton_relIso).

User need to download extra package.